### PR TITLE
Fix Search Block Controller SEO Paging String

### DIFF
--- a/concrete/blocks/search/controller.php
+++ b/concrete/blocks/search/controller.php
@@ -12,6 +12,8 @@ use Core;
 use Database;
 use Page;
 use Request;
+use Concrete\Core\Support\Facade\Config;
+use Concrete\Core\Url\SeoCanonical;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
@@ -269,6 +271,18 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $this->btCacheBlockOutput;
     }
 
+    /**
+     * Default on_start method.
+     */
+    public function on_start() {
+	    $paging = $this->request->request(Config::get('concrete.seo.paging_string'));
+		if ($paging && $paging >= 2) {
+	        /** @var SeoCanonical $seoCanonical */
+	        $seoCanonical = $this->app->make(SeoCanonical::class);
+	        $seoCanonical->addIncludedQuerystringParameter(Config::get('concrete.seo.paging_string'));
+	    }
+	}
+    
     /**
      * Default view method.
      */

--- a/concrete/blocks/search/controller.php
+++ b/concrete/blocks/search/controller.php
@@ -275,13 +275,13 @@ class Controller extends BlockController implements UsesFeatureInterface
      * Default on_start method.
      */
     public function on_start() {
-	    $paging = $this->request->request(Config::get('concrete.seo.paging_string'));
-		if ($paging && $paging >= 2) {
-	        /** @var SeoCanonical $seoCanonical */
-	        $seoCanonical = $this->app->make(SeoCanonical::class);
-	        $seoCanonical->addIncludedQuerystringParameter(Config::get('concrete.seo.paging_string'));
-	    }
-	}
+        $paging = $this->request->request(Config::get('concrete.seo.paging_string'));
+        if ($paging && $paging >= 2) {
+            /** @var SeoCanonical $seoCanonical */
+            $seoCanonical = $this->app->make(SeoCanonical::class);
+            $seoCanonical->addIncludedQuerystringParameter(Config::get('concrete.seo.paging_string'));
+        }
+    }
     
     /**
      * Default view method.


### PR DESCRIPTION
Currently the Search block does not properly deal with canonical url's like the page list block does.  We currently see the ccm_paging_p query string variables in the canonical url because ccm_paging_p is hard wired in site.php.  If we change the concrete.seo.paging_string config variable, it is not reflected in the canonical url for the search block.

With these modifications I'm able to remove the hard wired ccm_paging_p from site.php and the search block works as expected if the paging string is changed.   May there be other unintended consequences related to removing this config variable??  I'm hopefully moving towards us not needing that hard wired!

Background:  https://github.com/concretecms/concretecms/issues/12013